### PR TITLE
Fixed Typo

### DIFF
--- a/dictionary/professions.js
+++ b/dictionary/professions.js
@@ -11,7 +11,7 @@ module.exports = [
   'Actor',
   'Actuary',
   'Administrator',
-  'Adventurer ',
+  'Adventurer',
   'Archaeologist',
   'Agent',
   'Agriculturist',


### PR DESCRIPTION
While using this package to generate email addresses, this extra space
caused invalid addresses to be generated. Removed extra space.